### PR TITLE
Add signal strength monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ CONFIG_MKNOD=y
 CONFIG_WC=y
 ```
 
+# Properties
+
+In addition to the common `vintage_net` properties for all interface types, this technology reports the following:
+
+| Property      | Values         | Description                                |
+| ------------- | -------------- | ------------------------------------------ |
+| `signal_dbm`  | `-109..-53`    | An integer between the values -109 and -53 |
+| `signal_rssi` | `0-31` or `99` | An integer between 0-31, 99                |
+
 ## Serial AT command debugging
 
 If you are running this on a nerves device and have
@@ -81,14 +90,14 @@ iex> Elixircom.run("/dev/ttyUSB2", speed: 115200)
 OK
 ```
 
-Command    | Description
------------|-----------------------
-at+csq     | Signal Strength
-at+csq=?   | Query supported signal strength format
-at+cfun?   | Level of functionality
-at+cfun=?  | Query supported functionality levels
-at+creg?   | Check if the modem has registered to a provider.
-at+cgreg?  | Same as above for some modems
+| Command   | Description                                      |
+| --------- | ------------------------------------------------ |
+| at+csq    | Signal Strength                                  |
+| at+csq=?  | Query supported signal strength format           |
+| at+cfun?  | Level of functionality                           |
+| at+cfun=? | Query supported functionality levels             |
+| at+creg?  | Check if the modem has registered to a provider. |
+| at+cgreg? | Same as above for some modems                    |
 
 `VintageNetLTE` makes it easy to add cellular support to your device.
 

--- a/lib/vintage_net_lte.ex
+++ b/lib/vintage_net_lte.ex
@@ -3,6 +3,7 @@ defmodule VintageNetLTE do
 
   alias VintageNet.Interface.RawConfig
   alias VintageNetLTE.ServiceProvider.Twilio
+  alias VintageNetLTE.SignalStrengthMonitor
 
   @impl true
   def normalize(config), do: config
@@ -18,7 +19,12 @@ defmodule VintageNetLTE do
       {:fun, __MODULE__, :run_mknod, []}
     ]
 
-    child_specs = [make_pppd_spec(opts)]
+    # TODO: figure out a nicer way to specify options for
+    # polling the signal strength
+    child_specs = [
+      {SignalStrengthMonitor, [ifname: ifname, tty: "/dev/ttyUSB2", speed: 115_200]},
+      make_pppd_spec(opts)
+    ]
 
     %RawConfig{
       ifname: ifname,

--- a/lib/vintage_net_lte/at_buffer.ex
+++ b/lib/vintage_net_lte/at_buffer.ex
@@ -1,0 +1,37 @@
+defmodule VintageNetLTE.ATBuffer do
+  @moduledoc false
+
+  alias VintageNetLTE.ATParser
+
+  @doc """
+  Handle a new AT report and add it to the buffer
+
+  If the report is as `:ok_report` this will return that the AT communication
+  is complete and the consumer can process information further.
+
+  If the report is not complete, it will let the consumer know to continue
+  waiting for more information from the modem.
+  """
+  @spec handle_report(list(), binary) :: {:continue, list()} | {:complete, list()}
+  def handle_report(at_buffer, report) do
+    case ATParser.parse_report(report) do
+      :ok_report ->
+        {:complete, Enum.reverse(at_buffer)}
+
+      parsed_report ->
+        {:continue, [parsed_report | at_buffer]}
+    end
+  end
+
+  @doc """
+  Filter the buffer list to only contain reports that
+  we are interested in
+  """
+  @spec filter_reports(list(), ATParser.report_type()) :: list()
+  def filter_reports(report_buffer, report_type) do
+    Enum.filter(report_buffer, fn
+      {^report_type, _report_data} -> true
+      _ -> false
+    end)
+  end
+end

--- a/lib/vintage_net_lte/at_parser.ex
+++ b/lib/vintage_net_lte/at_parser.ex
@@ -1,0 +1,29 @@
+defmodule VintageNetLTE.ATParser do
+  @moduledoc false
+
+  @type report_type :: atom()
+  @type report_data :: term()
+
+  @type report :: {report_type(), term()} | :ok_report
+
+  @doc """
+  Parse the raw AT report into an Elixir data structure
+  """
+  @spec parse_report(binary()) :: report()
+  def parse_report(resp) do
+    case resp do
+      "OK" -> :ok_report
+      "+CSQ" <> _rest -> decode_csq_resp(resp)
+      other -> {:unsupported, other}
+    end
+  end
+
+  defp decode_csq_resp(resp) do
+    [_csq_label, values] = String.split(resp, ":")
+    [rssi_str, bit_error_rate_str] = String.split(values, ~r/\s|,/, trim: true)
+    rssi = String.to_integer(rssi_str)
+    bit_error_rate = String.to_integer(bit_error_rate_str)
+
+    {:csq_report, {rssi, bit_error_rate}}
+  end
+end

--- a/lib/vintage_net_lte/pppd_notifications.ex
+++ b/lib/vintage_net_lte/pppd_notifications.ex
@@ -2,7 +2,6 @@ defmodule VintageNetLTE.PPPDNotifications do
   @behaviour VintageNetLTE.ToElixir.PPPDHandler
 
   alias VintageNet.{NameResolver, PropertyTable, RouteManager}
-
   require Logger
 
   defp parse_address(address) do
@@ -37,6 +36,7 @@ defmodule VintageNetLTE.PPPDNotifications do
     NameResolver.setup(ifname, domain, [dns1, dns2])
 
     PropertyTable.put(VintageNet, ["interface", ifname, "connection"], :internet)
+
     :ok
   end
 

--- a/lib/vintage_net_lte/signal_strength.ex
+++ b/lib/vintage_net_lte/signal_strength.ex
@@ -1,0 +1,53 @@
+defmodule VintageNetLTE.SignalStrength do
+  @moduledoc """
+  Functionality for working with the signal strength of an LTE modem
+  """
+
+  alias VintageNet.PropertyTable
+
+  @doc """
+  Get the dbm value from the RSSI value
+
+  This is calculated by: `worse_dBm + rssi * 2
+
+  Where the `worse_dBm` is `-113`
+
+  The best possible RSSI value is `31`.
+
+  For more resources about the conversion formula see section 6.3
+  from https://www.quectel.com/UploadImage/Downlad/Quectel_BG96_AT_Commands_Manual_V2.1.pdf
+  """
+  @spec rssi_to_dbm(non_neg_integer()) :: integer() | :unknown
+  def rssi_to_dbm(99), do: :unknown
+
+  def rssi_to_dbm(rssi) when rssi <= 31 do
+    -113 + rssi * 2
+  end
+
+  @doc """
+  Set the signal strength related properties on VintageNet's property table.
+
+  Supported properties:
+
+  * `signal_rssi` - a value that represents the percent of signal strength
+    `0-30`
+  * `signal_dbm` - a value that represents the dBm of the signal strength
+    `-109..-53`
+  """
+  @spec set_signal_properties(non_neg_integer(), VintageNet.ifname()) :: :ok
+  def set_signal_properties(rssi, ifname) do
+    dbm = rssi_to_dbm(rssi)
+    :ok = set_rssi_property(rssi, ifname)
+    :ok = set_dbm_property(dbm, ifname)
+
+    :ok
+  end
+
+  defp set_dbm_property(signal_dbm, ifname) do
+    PropertyTable.put(VintageNet, ["interface", ifname, "lte", "signal_dbm"], signal_dbm)
+  end
+
+  defp set_rssi_property(rssi, ifname) do
+    PropertyTable.put(VintageNet, ["interface", ifname, "lte", "signal_rssi"], rssi)
+  end
+end

--- a/lib/vintage_net_lte/signal_strength_monitor.ex
+++ b/lib/vintage_net_lte/signal_strength_monitor.ex
@@ -1,0 +1,96 @@
+defmodule VintageNetLTE.SignalStrengthMonitor do
+  @moduledoc """
+  Monitor the signal strength of the LTE modem
+
+  This currently works by opening a UART connection to a the modem and queries
+  the signal strength at a set interval.
+  """
+
+  @typedoc """
+  Options for the monitor
+
+  * `:speed` - the baud rate of the serial connection (default 115_200)
+  * `:interval` - the interval to query the signal strength (default 5 seconds)
+  * `:ifname` - the interface name for the `ppp` connection (required)
+  * `:tty` - the tty device to connect to (required)
+  """
+  @type opt ::
+          {:speed, non_neg_integer()}
+          | {:interval, non_neg_integer()}
+          | {:ifname, String.t()}
+          | {:tty, String.t()}
+
+  use GenServer
+
+  alias Circuits.UART
+  alias VintageNetLTE.{SignalStrength, ATBuffer}
+
+  @spec start_link([opt]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    speed = Keyword.get(opts, :speed, 115_200)
+    interval = Keyword.get(opts, :interval, 5_000)
+    tty = Keyword.fetch!(opts, :tty)
+    ifname = Keyword.fetch!(opts, :ifname)
+
+    {:ok, uart} = UART.start_link()
+
+    :ok =
+      UART.open(uart, tty,
+        speed: speed,
+        framing: {UART.Framing.Line, separator: "\r\n"}
+      )
+
+    timer = signal_check_timer(interval)
+
+    {:ok,
+     %{
+       uart: uart,
+       timer: timer,
+       ifname: ifname,
+       tty: tty,
+       interval: interval,
+       response_buffer: []
+     }}
+  end
+
+  @impl true
+  def handle_info(
+        {:circuits_uart, tty, at_response},
+        %{tty: tty, response_buffer: buffer, ifname: ifname} = state
+      ) do
+    case ATBuffer.handle_report(buffer, at_response) do
+      {:continue, at_buffer} ->
+        {:noreply, %{state | response_buffer: at_buffer}}
+
+      {:complete, reports} ->
+        [{:csq_report, {rssi, _error_rate}}] = ATBuffer.filter_reports(reports, :csq_report)
+
+        SignalStrength.set_signal_properties(rssi, ifname)
+
+        {:noreply, %{state | response_buffer: []}}
+    end
+  end
+
+  @impl true
+  def handle_info(:signal_check, state) do
+    %{uart: uart, interval: interval} = state
+
+    :ok = UART.write(uart, "AT+CSQ")
+
+    {:noreply, %{state | timer: signal_check_timer(interval)}}
+  end
+
+  @impl true
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
+  defp signal_check_timer(interval) do
+    Process.send_after(self(), :signal_check, interval)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,8 @@ defmodule VintageNetLTE.MixProject do
       {:muontrap, "~> 0.5.0"},
       {:ex_doc, "~> 0.19", only: :docs, runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev, :test], runtime: false},
+      {:circuits_uart, "~> 1.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "circuits_uart": {:hex, :circuits_uart, "1.4.1", "f8151bfb5ac29fe2e791eec00bc6ec298fdb8fa81ddd80bdb0f9f2828f20d7b8", [:mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},

--- a/test/vintage_net_lte/at_buffer_test.exs
+++ b/test/vintage_net_lte/at_buffer_test.exs
@@ -1,0 +1,44 @@
+defmodule VintageNetLTE.ATBufferTest do
+  use ExUnit.Case
+
+  alias VintageNetLTE.ATBuffer
+
+  test "handles a new report" do
+    buffer = []
+    report = "+CSQ: 24,0"
+
+    assert {:continue, [{:csq_report, {24, 0}}]} == ATBuffer.handle_report(buffer, report)
+  end
+
+  test "handles report completion" do
+    buffer = [{:csq_report, {24, 0}}]
+
+    assert {:complete, buffer} == ATBuffer.handle_report(buffer, "OK")
+  end
+
+  test "handles completion when there are extra reports" do
+    buffer = []
+
+    {:continue, new_buffer} = ATBuffer.handle_report(buffer, "+CSQ: 56, 12")
+    {:continue, new_buffer} = ATBuffer.handle_report(new_buffer, "Quectel")
+    {:continue, new_buffer} = ATBuffer.handle_report(new_buffer, "Revision: BG96MAR01A01M1G")
+
+    expected_buffer = [
+      {:csq_report, {56, 12}},
+      {:unsupported, "Quectel"},
+      {:unsupported, "Revision: BG96MAR01A01M1G"}
+    ]
+
+    assert {:complete, expected_buffer} == ATBuffer.handle_report(new_buffer, "OK")
+  end
+
+  test "allows filtering on report type" do
+    buffer = []
+
+    {:continue, new_buffer} = ATBuffer.handle_report(buffer, "+CSQ: 56, 12")
+    {:continue, new_buffer} = ATBuffer.handle_report(new_buffer, "Quectel")
+    {:continue, new_buffer} = ATBuffer.handle_report(new_buffer, "Revision: BG96MAR01A01M1G")
+
+    assert [{:csq_report, {56, 12}}] == ATBuffer.filter_reports(new_buffer, :csq_report)
+  end
+end

--- a/test/vintage_net_lte/at_parser_test.exs
+++ b/test/vintage_net_lte/at_parser_test.exs
@@ -1,0 +1,19 @@
+defmodule VintageNetLTE.ATParserTest do
+  use ExUnit.Case
+
+  alias VintageNetLTE.ATParser
+
+  test "parses CSQ report" do
+    assert {:csq_report, {12, 3}} == ATParser.parse_report("+CSQ: 12,3")
+    assert {:csq_report, {15, 1}} == ATParser.parse_report("+CSQ:15,1")
+  end
+
+  test "parses OK report" do
+    assert :ok_report == ATParser.parse_report("OK")
+  end
+
+  test "handles unsupported report" do
+    assert {:unsupported, "^HCSQ:\"WCDMA\",33,19,37"} ==
+             ATParser.parse_report("^HCSQ:\"WCDMA\",33,19,37")
+  end
+end

--- a/test/vintage_net_lte/signal_strength_test.exs
+++ b/test/vintage_net_lte/signal_strength_test.exs
@@ -1,0 +1,26 @@
+defmodule VintageNetLTE.SignalStrengthTest do
+  use ExUnit.Case
+
+  alias VintageNet.PropertyTable
+  alias VintageNetLTE.SignalStrength
+
+  test "converts rssi into dBm" do
+    dbms = for rssi <- 2..30, do: SignalStrength.rssi_to_dbm(rssi)
+
+    assert -53 == Enum.max(dbms)
+    assert -109 == Enum.min(dbms)
+  end
+
+  test "sets the property table for the signal strength correctly" do
+    :ok = SignalStrength.set_signal_properties(24, "ppp0_test")
+
+    assert 24 ==
+             PropertyTable.get(VintageNet, ppp0_property("ppp0_test", "signal_rssi"))
+
+    assert -65 == PropertyTable.get(VintageNet, ppp0_property("ppp0_test", "signal_dbm"))
+  end
+
+  defp ppp0_property(ifname, property) do
+    ["interface", ifname, "lte", property]
+  end
+end

--- a/test/vintage_net_lte_test.exs
+++ b/test/vintage_net_lte_test.exs
@@ -19,6 +19,8 @@ defmodule VintageNetLTETest do
       ],
       files: [{"/tmp/vintage_net/twilio", Twilio.chatscript()}],
       child_specs: [
+        {VintageNetLTE.SignalStrengthMonitor,
+         [ifname: "ppp0", tty: "/dev/ttyUSB2", speed: 115_200]},
         {MuonTrap.Daemon,
          [
            "pppd",


### PR DESCRIPTION
Add support to monitor the signal strength in both dBm and percent. This
uses `VintageNet.PropertyTable` from consuming applications to subscribe
to the changes in the signal strength over time.