### PR TITLE
Add a modem lookup table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,15 @@ To get this technology running with VintageNet run the following:
 VintageNet.configure("ppp0", %{type: VintageNetLTE, modem: modem, provider: provider_info}, persist: false)
 ```
 
-Where `modem` is a module that implements the `VintageNetLTE.Modem` behaviour.
-
-The `:provider` key contains the following information:
-
-* `:apn` - The service provider's APN
-
 ```elixir
 config :vintage_net,
   config: [
-    {"ppp0", %{type: VintageNetLTE, modem: VintageNetLTE.Modems.QuectelBG96, provider: %{apn: "wireless.twilio.com"}}}
+    {"ppp0", %{type: VintageNetLTE, modem: "Quectel BG96", provider: "Twilio"}}
 ```
 
 Currently supported modem:
 
-* `VintageNetLTE.Modems.QuectelBG96`
+- `VintageNetLTE.Modems.QuectelBG96`
 
 ## System requirements
 
@@ -79,13 +73,29 @@ CONFIG_MKNOD=y
 CONFIG_WC=y
 ```
 
+## Custom Modems
+
+`VintageNetLTE` allows you add your modem implementation to it's runtime by adding
+it to the configuration:
+
+```
+config :vintage_net_lte,
+  extra_modems: [
+    {"Quectel Modem", "AT&T", MyQuectelModem}
+  ]
+```
+
+The modem definition a 3 item tuple in this format
+`{modem_name, provider, modem_module}` where the modem module is module that
+implements the `VintageNetLTE.Modem` behaviour.
+
 ## VitnageNet Properties
 
 In addition to the common `vintage_net` properties for all interface types, this technology reports the following:
 
-| Property      | Values         | Description                    |
-| ------------- | -------------- | -------------------------------|
-| `signal_rssi` | `0-31` or `99` | An integer between 0-31 or 99  |
+| Property      | Values         | Description                   |
+| ------------- | -------------- | ----------------------------- |
+| `signal_rssi` | `0-31` or `99` | An integer between 0-31 or 99 |
 
 ## Serial AT command debugging
 
@@ -105,14 +115,14 @@ iex> Elixircom.run("/dev/ttyUSB2", speed: 115200)
 OK
 ```
 
-Command    | Description
------------|-----------------------
-at+csq     | Signal Strength
-at+csq=?   | Query supported signal strength format
-at+cfun?   | Level of functionality
-at+cfun=?  | Query supported functionality levels
-at+creg?   | Check if the modem has registered to a provider.
-at+cgreg?  | Same as above for some modems
+| Command   | Description                                      |
+| --------- | ------------------------------------------------ |
+| at+csq    | Signal Strength                                  |
+| at+csq=?  | Query supported signal strength format           |
+| at+cfun?  | Level of functionality                           |
+| at+cfun=? | Query supported functionality levels             |
+| at+creg?  | Check if the modem has registered to a provider. |
+| at+cgreg? | Same as above for some modems                    |
 
 `VintageNetLTE` makes it easy to add cellular support to your device.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,4 +11,7 @@ config :vintage_net,
   bin_ip: "false"
 
 config :vintage_net_lte,
-  pppd_handler: VintageNetLTE.CapturingPPPDHandler
+  pppd_handler: VintageNetLTE.CapturingPPPDHandler,
+  extra_modems: [
+    {"Mock", "TestProvider", VintageNetLTE.Modems.MockModem}
+  ]

--- a/lib/vintage_net_lte.ex
+++ b/lib/vintage_net_lte.ex
@@ -2,23 +2,14 @@ defmodule VintageNetLTE do
   @behaviour VintageNet.Technology
 
   alias VintageNet.Interface.RawConfig
-  alias VintageNetLTE.{ATRunner, SignalMonitor}
-
-  @typedoc """
-  The provider information for provider specific configuration
-
-  * `:apn` - The service provider's APN
-  """
-  @type provider_info :: %{
-          apn: String.t()
-        }
+  alias VintageNetLTE.{ATRunner, SignalMonitor, Modems}
 
   @impl true
   def normalize(config), do: config
 
   @impl true
   def to_raw_config(ifname, %{type: __MODULE__, modem: modem, provider: provider} = config, opts) do
-    modem_spec = modem.spec(provider)
+    modem_spec = Modems.get_modem_spec(modem, provider)
     files = [{chatscript_path(ifname, opts), modem_spec.chatscript}]
 
     up_cmds = [

--- a/lib/vintage_net_lte/application.ex
+++ b/lib/vintage_net_lte/application.ex
@@ -5,7 +5,9 @@ defmodule VintageNetLTE.Application do
 
   def start(_type, _args) do
     children = [
-      {VintageNetLTE.ToElixir.Server, "/tmp/vintage_net/pppd_comms"}
+      {VintageNetLTE.ToElixir.Server, "/tmp/vintage_net/pppd_comms"},
+      {VintageNetLTE.Modems.Table,
+       extra_modems: Application.get_env(:vintage_net_lte, :extra_modems, [])}
     ]
 
     opts = [strategy: :rest_for_one, name: VintageNetLTE.Supervisor]

--- a/lib/vintage_net_lte/modem.ex
+++ b/lib/vintage_net_lte/modem.ex
@@ -22,5 +22,5 @@ defmodule VintageNetLTE.Modem do
   @doc """
   Return the modem spec
   """
-  @callback spec(VintageNetLTE.provider_info()) :: spec()
+  @callback spec(String.t()) :: spec()
 end

--- a/lib/vintage_net_lte/modems.ex
+++ b/lib/vintage_net_lte/modems.ex
@@ -1,0 +1,21 @@
+defmodule VintageNetLTE.Modems do
+  @moduledoc """
+  Module for working with supported modems
+  """
+  alias VintageNetLTE.Modems.Table
+  alias VintageNetLTE.Modem
+
+  @doc """
+  The specification for the modem given the modem and provider name
+
+  If there is no modem spec for that modem/provider pair this function will
+  return `nil`
+  """
+  @spec get_modem_spec(String.t(), String.t()) :: Modem.spec() | nil
+  def get_modem_spec(modem, provider) do
+    case Table.lookup(modem, provider) do
+      nil -> nil
+      modem -> modem.spec(provider)
+    end
+  end
+end

--- a/lib/vintage_net_lte/modems/quectel_BG96.ex
+++ b/lib/vintage_net_lte/modems/quectel_BG96.ex
@@ -43,7 +43,7 @@ defmodule VintageNetLTE.Modems.QuectelBG96 do
     }
   end
 
-  defp chatscript(provider_info) do
+  defp chatscript("Twilio") do
     """
     # Exit execution if module receives any of the following strings:
     ABORT 'BUSY'
@@ -68,7 +68,7 @@ defmodule VintageNetLTE.Modems.QuectelBG96 do
     OK ATQ0
 
     # Define PDP context
-    OK AT+CGDCONT=1,"IP","#{provider_info.apn}"
+    OK AT+CGDCONT=1,"IP","wireless.twilio.com"
 
     # ATDT = Attention Dial Tone
     OK ATDT*99***1#

--- a/lib/vintage_net_lte/modems/table.ex
+++ b/lib/vintage_net_lte/modems/table.ex
@@ -1,0 +1,58 @@
+defmodule VintageNetLTE.Modems.Table do
+  @moduledoc """
+  The list of modem names with provider names that point to a module that
+  implements the `VintageNetLTE.Modem` behaviour.
+
+  You can add custom modem support by passing `:extra_modems` field:
+
+  ```elixir
+  Table.start_link(extra_modems: [{"MyModem", "Verizon", MyModemModule}])
+  ```
+  """
+
+  use Agent
+
+  @typedoc """
+  Define a modem specification
+
+  This is a tuple that has the modem name, provider name, and the module that
+  implements the `VintageNetLTE.Modem` behaviour.
+  """
+  @type modem_def :: {String.t(), String.t(), module()}
+
+  @type opt :: {:extra_modems, [modem_def()]}
+
+  @spec start_link([opt]) :: Agent.on_start()
+  def start_link(opts) do
+    Agent.start_link(fn -> table(opts) end, name: __MODULE__)
+  end
+
+  @doc """
+  Look up the modem module for the given modem name and provider name
+  """
+  @spec lookup(String.t(), String.t()) :: module() | nil
+  def lookup(modem, provider) do
+    Agent.get(__MODULE__, &lookup(&1, modem, provider))
+  end
+
+  defp table(opts) do
+    extra_modems = Keyword.get(opts, :extra_modems)
+
+    Enum.reduce(extra_modems, default_modems(), fn {modem, provider, module}, acc ->
+      [{{modem, provider}, module} | acc]
+    end)
+  end
+
+  defp lookup(table, modem, provider) do
+    Enum.find_value(table, fn
+      {{^modem, ^provider}, modem_module} -> modem_module
+      _ -> nil
+    end)
+  end
+
+  defp default_modems() do
+    [
+      {{"Quectel BG96", "Twilio"}, VintageNetLTE.Modems.QuectelBG96}
+    ]
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,24 +1,102 @@
 %{
-  "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "circuits_uart": {:hex, :circuits_uart, "1.4.1", "f8151bfb5ac29fe2e791eec00bc6ec298fdb8fa81ddd80bdb0f9f2828f20d7b8", [:mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "excoveralls": {:hex, :excoveralls, "0.12.2", "a513defac45c59e310ac42fcf2b8ae96f1f85746410f30b1ff2b710a4b6cd44b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "gen_state_machine": {:hex, :gen_state_machine, "2.0.5", "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm"},
-  "hackney": {:hex, :hackney, "1.15.2", "07e33c794f8f8964ee86cebec1a8ed88db5070e52e904b8f12209773c1036085", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.5", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
-  "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
-  "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
-  "muontrap": {:hex, :muontrap, "0.5.1", "98fe96d0e616ee518860803a37a29eb23ffc2ca900047cb1bb7fd37521010093", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
-  "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
-  "vintage_net": {:hex, :vintage_net, "0.7.3", "5641307674ff988852593e297959ae2342df84ced80cbdfe2afa2fcf64395d26", [:make, :mix], [{:busybox, "~> 0.1.4", [hex: :busybox, repo: "hexpm", optional: true]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:gen_state_machine, "~> 2.0.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}, {:muontrap, "~> 0.5.1", [hex: :muontrap, repo: "hexpm", optional: false]}], "hexpm"},
+  certifi:
+    {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5",
+     [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}],
+     "hexpm"},
+  circuits_uart:
+    {:hex, :circuits_uart, "1.4.1",
+     "f8151bfb5ac29fe2e791eec00bc6ec298fdb8fa81ddd80bdb0f9f2828f20d7b8", [:mix],
+     [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  dialyxir:
+    {:hex, :dialyxir, "1.0.0-rc.7",
+     "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix],
+     [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  earmark:
+    {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd",
+     [:mix], [], "hexpm"},
+  elixir_make:
+    {:hex, :elixir_make, "0.6.0",
+     "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
+  erlex:
+    {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510",
+     [:mix], [], "hexpm"},
+  ex_doc:
+    {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6",
+     [:mix],
+     [
+       {:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]},
+       {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  excoveralls:
+    {:hex, :excoveralls, "0.12.2",
+     "a513defac45c59e310ac42fcf2b8ae96f1f85746410f30b1ff2b710a4b6cd44b", [:mix],
+     [
+       {:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]},
+       {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  gen_state_machine:
+    {:hex, :gen_state_machine, "2.0.5",
+     "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm"},
+  hackney:
+    {:hex, :hackney, "1.15.2", "07e33c794f8f8964ee86cebec1a8ed88db5070e52e904b8f12209773c1036085",
+     [:rebar3],
+     [
+       {:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]},
+       {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]},
+       {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]},
+       {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]},
+       {:ssl_verify_fun, "1.1.5", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  idna:
+    {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10",
+     [:rebar3],
+     [
+       {:unicode_util_compat, "0.4.1",
+        [hex: :unicode_util_compat, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  jason:
+    {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7",
+     [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  makeup:
+    {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc",
+     [:mix],
+     [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}],
+     "hexpm"},
+  makeup_elixir:
+    {:hex, :makeup_elixir, "0.14.0",
+     "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix],
+     [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  metrics:
+    {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486",
+     [:rebar3], [], "hexpm"},
+  mimerl:
+    {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3",
+     [:rebar3], [], "hexpm"},
+  muontrap:
+    {:hex, :muontrap, "0.5.1", "98fe96d0e616ee518860803a37a29eb23ffc2ca900047cb1bb7fd37521010093",
+     [:make, :mix],
+     [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  nimble_parsec:
+    {:hex, :nimble_parsec, "0.5.3",
+     "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
+  parse_trans:
+    {:hex, :parse_trans, "3.3.0",
+     "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
+  ssl_verify_fun:
+    {:hex, :ssl_verify_fun, "1.1.5",
+     "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3],
+     [], "hexpm"},
+  unicode_util_compat:
+    {:hex, :unicode_util_compat, "0.4.1",
+     "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  vintage_net:
+    {:hex, :vintage_net, "0.7.3",
+     "5641307674ff988852593e297959ae2342df84ced80cbdfe2afa2fcf64395d26", [:make, :mix],
+     [
+       {:busybox, "~> 0.1.4", [hex: :busybox, repo: "hexpm", optional: true]},
+       {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]},
+       {:gen_state_machine, "~> 2.0.0",
+        [hex: :gen_state_machine, repo: "hexpm", optional: false]},
+       {:muontrap, "~> 0.5.1", [hex: :muontrap, repo: "hexpm", optional: false]}
+     ], "hexpm"}
 }

--- a/test/vintage_net_lte/modems/quectel_BG96_test.exs
+++ b/test/vintage_net_lte/modems/quectel_BG96_test.exs
@@ -4,15 +4,13 @@ defmodule VintageNetLTE.Modems.QuectelBG96Test do
   alias VintageNetLTE.Modems.QuectelBG96
 
   test "returns correct spec" do
-    provider_info = %{apn: "test.apn.com"}
-
     assert %{
              serial_port: "ttyUSB3",
              serial_speed: 9600,
              chatscript: chatscript(),
              command_port: "ttyUSB2"
            } ==
-             QuectelBG96.spec(provider_info)
+             QuectelBG96.spec("Twilio")
   end
 
   defp chatscript() do
@@ -40,7 +38,7 @@ defmodule VintageNetLTE.Modems.QuectelBG96Test do
     OK ATQ0
 
     # Define PDP context
-    OK AT+CGDCONT=1,"IP","test.apn.com"
+    OK AT+CGDCONT=1,"IP","wireless.twilio.com"
 
     # ATDT = Attention Dial Tone
     OK ATDT*99***1#

--- a/test/vintage_net_lte/modems/table_test.exs
+++ b/test/vintage_net_lte/modems/table_test.exs
@@ -1,0 +1,9 @@
+defmodule VintageNetLTE.Modems.TableTest do
+  use ExUnit.Case
+
+  alias VintageNetLTE.Modems.{Table, QuectelBG96}
+
+  test "looks up modem module with modem name and provider name" do
+    assert QuectelBG96 == Table.lookup("Quectel BG96", "Twilio")
+  end
+end

--- a/test/vintage_net_lte/modems_test.exs
+++ b/test/vintage_net_lte/modems_test.exs
@@ -1,0 +1,13 @@
+defmodule VintageNetLTE.ModemsTest do
+  use ExUnit.Case
+
+  alias VintageNetLTE.Modems
+
+  alias VintageNetLTE.Modems.QuectelBG96
+
+  test "Get module specs for Quectel BG96 with Twilio" do
+    expected_spec = QuectelBG96.spec("Twilio")
+
+    assert expected_spec == Modems.get_modem_spec("Quectel BG96", "Twilio")
+  end
+end

--- a/test/vintage_net_lte_test.exs
+++ b/test/vintage_net_lte_test.exs
@@ -2,12 +2,11 @@ defmodule VintageNetLTETest do
   use ExUnit.Case
 
   alias VintageNet.Interface.RawConfig
-  alias VintageNetLTE.Modems.MockModem
   alias VintageNetLTE.{ATRunner, SignalMonitor}
 
   test "create an LTE configuration" do
     priv_dir = Application.app_dir(:vintage_net_lte, "priv")
-    input = %{type: VintageNetLTE, modem: MockModem, provider: %{}}
+    input = %{type: VintageNetLTE, modem: "Mock", provider: "TestProvider"}
 
     output = %RawConfig{
       ifname: "ppp0",


### PR DESCRIPTION
This allows more flexibility in terms of modem specifications paired
with the provider. Also, allows for users to add modem definitions to
the lookup table for modems that are supported in `VintageNetLTE`.