### PR TITLE
Add Twilio Super provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supported modems:
 Supported service providers:
 
 * `"Twilio"`
+* `"Twilio Super"`
 
 ## System requirements
 

--- a/lib/vintage_net_lte/service_providers.ex
+++ b/lib/vintage_net_lte/service_providers.ex
@@ -13,7 +13,10 @@ defmodule VintageNetLTE.ServiceProviders do
   ```
   """
 
-  @default_service_providers [{"Twilio", apn: "wireless.twilio.com"}]
+  @default_service_providers [
+    {"Twilio", apn: "wireless.twilio.com"},
+    {"Twilio Super", apn: "super"}
+  ]
 
   @doc """
   Return the APN for the specified service provider


### PR DESCRIPTION
This provider is used when the modem is using the Super SIM from Twilio.
This SIM allows for connecting to Cat M1 connections when coverage for
Cat M1 using the base Twilio SIM card is not available.